### PR TITLE
fix path error

### DIFF
--- a/bin/legofy
+++ b/bin/legofy
@@ -2,4 +2,4 @@
 
 'use strict'
 
-require('../dist/cli').default()
+require('../lib/cli').default()


### PR DESCRIPTION
Using node-legofy on command line would throws the error below, it seems like it's a problem caused by not changing the path in `bin/legofy.js` after #29.

``` javascript

module.js:339
    throw err;
    ^

Error: Cannot find module '../dist/cli'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/Users/plrthink/.nvm/versions/node/v4.2.3/lib/node_modules/node-legofy/bin/legofy:5:1)
    at Module._compile (module.js:435:26)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
```

This PR would fix this.
